### PR TITLE
Add global 'use strict' requirements

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,4 +3,6 @@
 // This file is licensed under the Artistic License 2.0.
 // License text available at https://opensource.org/licenses/Artistic-2.0
 
+'use strict';
+
 module.exports = require('./strongloop.json');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-strongloop",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "StrongLoop core coding conventions",
   "main": "index.js",
   "scripts": {

--- a/strongloop.json
+++ b/strongloop.json
@@ -100,6 +100,7 @@
     "space-infix-ops": 2,
     "space-unary-ops": [2, { "words": true, "nonwords": false }],
     "spaced-comment": [2, "always", { "markers": ["global", "globals", "eslint", "eslint-disable", "*package", "!", ","] }],
+    "strict": [2, "global"],
     "use-isnan": 2,
     "valid-typeof": 2,
     "wrap-iife": [2, "any"],


### PR DESCRIPTION
connected to https://github.com/strongloop-internal/scrum-nodeops/issues/1596

Require 'use strict' at the top of all modules.
(Used to be a default rule, but disabled as a default in 2.0)
